### PR TITLE
Fix starring messages from other servers

### DIFF
--- a/starboard.js
+++ b/starboard.js
@@ -45,7 +45,7 @@ const starboardReact = async (config, channel, reaction, _user) => {
     if (reaction.count >= config.reaction_threshold) {
         switch (reaction.emoji.name) {
         case '⭐':
-            if (!hasBeenStarboarded(reaction.message)) {
+            if (!hasBeenStarboarded(reaction.message) && reaction.server.id == config.guild_2025) {
                 console.log(`Starboarding ${reaction.message.id}`);
                 rememberStarboard(reaction.message);
                 addToStarboard(reaction.message, channel, config);


### PR DESCRIPTION
I didn't actually test this but I think this is what I should do according to the docs?

Also, would it be a problem if someone stars a message in a private message/group with Tim? In that case, `reaction.server` would be undefined